### PR TITLE
Allow tracks to be archived

### DIFF
--- a/Tickmate/Tickmate.xcodeproj/project.pbxproj
+++ b/Tickmate/Tickmate.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		59FBCF2A25E07BD8007B114F /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FBCF2925E07BD8007B114F /* Persistence.swift */; };
 		59FBCF2D25E07BD8007B114F /* Tickmate.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 59FBCF2B25E07BD8007B114F /* Tickmate.xcdatamodeld */; };
 		B91ED2862B5B89640049EDB7 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = B91ED2852B5B89640049EDB7 /* SwiftUIIntrospect */; };
+		B93BBF092B9CCAFC007E810A /* ArchivedTracksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93BBF082B9CCAFC007E810A /* ArchivedTracksView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -188,6 +189,7 @@
 		59FBCF2925E07BD8007B114F /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		59FBCF2C25E07BD8007B114F /* Tickmate.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Tickmate.xcdatamodel; sourceTree = "<group>"; };
 		59FBCF2E25E07BD8007B114F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B93BBF082B9CCAFC007E810A /* ArchivedTracksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedTracksView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -354,6 +356,7 @@
 				5931643E26855EB8005DDA1A /* TickView.swift */,
 				59EF632825E5CD4B003E7259 /* TrackView.swift */,
 				59C23A6B25E70E1A00AFBC4B /* SymbolPicker.swift */,
+				B93BBF082B9CCAFC007E810A /* ArchivedTracksView.swift */,
 				599D9F5125EC5A4900DF3795 /* TracksView.swift */,
 				5991968E25F813ED003215CC /* PresetTracksView.swift */,
 				59E6E14D25F88177008A74A9 /* SettingsView.swift */,
@@ -596,6 +599,7 @@
 				5991969225F817F7003215CC /* PresetTracks.swift in Sources */,
 				599D9F5225EC5A4900DF3795 /* TracksView.swift in Sources */,
 				59F6170926671C2100CC78E1 /* AlertItem.swift in Sources */,
+				B93BBF092B9CCAFC007E810A /* ArchivedTracksView.swift in Sources */,
 				59F6EA9D25E369830069DF40 /* Tickmate+Convenience.swift in Sources */,
 				59A0D8932645CF1600E01E61 /* View+DismissKeyboard.swift in Sources */,
 				59EF633725E5DC93003E7259 /* TextWithCaption.swift in Sources */,

--- a/Tickmate/Tickmate/Controllers/Persistence.swift
+++ b/Tickmate/Tickmate/Controllers/Persistence.swift
@@ -23,14 +23,16 @@ class PersistenceController {
         result.previewGroup = group
         
         let dateString = TrackController.iso8601.string(from: Date() - 5.days)
-        for i: Int16 in 0..<5 {
+        for i: Int16 in 0..<6 {
             let track = Track(
                 name: String(UUID().uuidString.dropLast(28)),
-                multiple: i > 0,
+                multiple: 1...2 ~= i,
                 reversed: i == 2,
                 startDate: dateString,
                 index: i,
-                context: viewContext)
+                isArchived: i == 5,
+                context: viewContext
+            )
             
             if i == 1 {
                 for day in 0..<5 {

--- a/Tickmate/Tickmate/Controllers/Persistence.swift
+++ b/Tickmate/Tickmate/Controllers/Persistence.swift
@@ -2,7 +2,7 @@
 //  Persistence.swift
 //  Tickmate
 //
-//  Created by Isaac Lyons on 2/19/21.
+//  Created by Elaine Lyons on 2/19/21.
 //
 
 import SwiftUI

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -270,6 +270,7 @@ class TrackController: NSObject, ObservableObject {
         }
     }
     
+    // TODO: Update this to instead save _now_, but prevent a second save from happening for 5 seconds (or whatever interval)
     /// Schedule a Core Data save on the current view context.
     ///
     /// Call this function when you want to save a small change when other small changes may happen soon after.

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -41,12 +41,14 @@ class TrackController: NSObject, ObservableObject {
         
         let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
         fetchRequest.sortDescriptors = Self.sortDescriptors
+        fetchRequest.predicate = NSPredicate(format: "isArchived == NO")
         
         let frc = NSFetchedResultsController<Track>(
             fetchRequest: fetchRequest,
             managedObjectContext: context,
             sectionNameKeyPath: nil,
-            cacheName: nil)
+            cacheName: nil
+        )
         
         if observeChanges {
             frc.delegate = self
@@ -55,6 +57,34 @@ class TrackController: NSObject, ObservableObject {
         do {
             try frc.performFetch()
             print("TrackController FRC fetched.")
+        } catch {
+            NSLog("Error performing Tracks fetch: \(error)")
+        }
+        
+        return frc
+    }()
+    
+    lazy var archivedTracksFRC: NSFetchedResultsController<Track> = {
+        let context = (preview ? PersistenceController.preview : PersistenceController.shared).container.viewContext
+        
+        let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
+        fetchRequest.sortDescriptors = Self.sortDescriptors
+        fetchRequest.predicate = NSPredicate(format: "isArchived == YES")
+        
+        let frc = NSFetchedResultsController<Track>(
+            fetchRequest: fetchRequest,
+            managedObjectContext: context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+        
+        if observeChanges {
+            frc.delegate = self
+        }
+        
+        do {
+            try frc.performFetch()
+            print("TrackController archived FRC fetched.")
         } catch {
             NSLog("Error performing Tracks fetch: \(error)")
         }

--- a/Tickmate/Tickmate/Model/Tickmate+Convenience.swift
+++ b/Tickmate/Tickmate/Model/Tickmate+Convenience.swift
@@ -2,7 +2,7 @@
 //  Tickmate+Convenience.swift
 //  Tickmate
 //
-//  Created by Isaac Lyons on 2/21/21.
+//  Created by Elaine Lyons on 2/21/21.
 //
 
 import CoreData

--- a/Tickmate/Tickmate/Model/Tickmate+Convenience.swift
+++ b/Tickmate/Tickmate/Model/Tickmate+Convenience.swift
@@ -48,6 +48,16 @@ extension Track {
         let luma = (0.299 * r + 0.587 * g + 0.114 * b) / 255
         return luma < 2/3
     }
+    
+    /// Archives the Track and removes it from all groups.
+    func archive() {
+        isArchived = true
+        // ContentView only displays Groups that aren't empty, but it would take
+        // a subquery to first filter out archived Tracks, but SwiftUI then
+        // won't dynamically respond to those changes, so it's easiest to just
+        // remove archived tracks from any groups.
+        self.groups = Set<TrackGroup>() as NSSet
+    }
 }
 
 extension Tick {

--- a/Tickmate/Tickmate/Model/Tickmate+Convenience.swift
+++ b/Tickmate/Tickmate/Model/Tickmate+Convenience.swift
@@ -19,7 +19,17 @@ extension TrackGroup {
 
 extension Track {
     @discardableResult
-    convenience init(name: String, color: Int32? = nil, multiple: Bool = false, reversed: Bool = false, startDate: String, systemImage: String? = nil, index: Int16, context moc: NSManagedObjectContext) {
+    convenience init(
+        name: String,
+        color: Int32? = nil,
+        multiple: Bool = false,
+        reversed: Bool = false,
+        startDate: String,
+        systemImage: String? = nil,
+        index: Int16,
+        isArchived: Bool = false,
+        context moc: NSManagedObjectContext
+    ) {
         self.init(context: moc)
         self.name = name
         self.color = color ?? Int32(Color(hue: Double.random(in: 0...1), saturation: 1, brightness: 1).rgb)
@@ -28,6 +38,7 @@ extension Track {
         self.startDate = startDate
         self.systemImage = systemImage ?? SymbolsList.randomElement()
         self.index = index
+        self.isArchived = isArchived
     }
     
     var lightText: Bool {

--- a/Tickmate/Tickmate/Model/Tickmate.xcdatamodeld/Tickmate.xcdatamodel/contents
+++ b/Tickmate/Tickmate/Model/Tickmate.xcdatamodeld/Tickmate.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E232" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23C71" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
     <entity name="Tick" representedClassName="Tick" syncable="YES" codeGenerationType="class">
         <attribute name="count" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="dayOffset" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -11,6 +11,7 @@
         <attribute name="color" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="enabled" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="index" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="multiple" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="reversed" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -24,9 +25,4 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="tracks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Track" inverseName="groups" inverseEntity="Track"/>
     </entity>
-    <elements>
-        <element name="Tick" positionX="-45" positionY="36" width="128" height="104"/>
-        <element name="Track" positionX="-54" positionY="-9" width="128" height="179"/>
-        <element name="TrackGroup" positionX="-45" positionY="63" width="128" height="74"/>
-    </elements>
 </model>

--- a/Tickmate/Tickmate/Model/TrackGroups.swift
+++ b/Tickmate/Tickmate/Model/TrackGroups.swift
@@ -2,7 +2,7 @@
 //  TrackGroups.swift
 //  Tickmate
 //
-//  Created by Isaac Lyons on 5/31/21.
+//  Created by Elaine Lyons on 5/31/21.
 //
 
 import Foundation

--- a/Tickmate/Tickmate/Model/TrackGroups.swift
+++ b/Tickmate/Tickmate/Model/TrackGroups.swift
@@ -16,6 +16,15 @@ class TrackGroups: ObservableObject {
     }
     
     func load(_ track: Track) {
+        guard !track.isArchived else {
+            // Archived tracks should not have any groups.
+            // Remove any that might be there from sync conflicts.
+            set.removeAll()
+            array.removeAll()
+            save(to: track)
+            return
+        }
+        
         guard let groups = track.groups as? Set<TrackGroup> else { return }
         set = groups
         array = groups.sorted(by: { $0.index < $1.index })

--- a/Tickmate/Tickmate/Supplementary Views/StateEditButton.swift
+++ b/Tickmate/Tickmate/Supplementary Views/StateEditButton.swift
@@ -17,18 +17,13 @@ struct StateEditButton: View {
     var onTap: () -> Void = {}
     
     var body: some View {
-        Button {
+        Button(editMode.isEditing ? doneText : "Edit") {
             withAnimation {
                 editMode = editMode == .active ? .inactive : .active
             }
             onTap()
-        } label: {
-            if editMode.isEditing {
-                Text(doneText)
-            } else {
-                Text("Edit")
-            }
         }
+        .animation(.none, value: editMode)
     }
 }
 

--- a/Tickmate/Tickmate/Supplementary Views/StateEditButton.swift
+++ b/Tickmate/Tickmate/Supplementary Views/StateEditButton.swift
@@ -2,7 +2,7 @@
 //  StateEditButton.swift
 //  Tickmate
 //
-//  Created by Isaac Lyons on 3/8/21.
+//  Created by Elaine Lyons on 3/8/21.
 //
 
 import SwiftUI

--- a/Tickmate/Tickmate/Views/ArchivedTracksView.swift
+++ b/Tickmate/Tickmate/Views/ArchivedTracksView.swift
@@ -1,0 +1,45 @@
+//
+//  ArchivedTracksView.swift
+//  Tickmate
+//
+//  Created by Elaine Lyons on 3/9/24.
+//
+
+import SwiftUI
+
+struct ArchivedTracksView: View {
+    
+    @Environment(\.managedObjectContext) private var moc
+    
+    @EnvironmentObject private var trackController: TrackController
+    
+    @State private var selection: Track?
+    
+    private var tracks: [Track] {
+        trackController.archivedTracksFRC.fetchedObjects ?? []
+    }
+    
+    var body: some View {
+        Form {
+            Section {
+                ForEach(tracks) { track in
+                    // TODO: Remove `enabled` toggle
+                    TrackCell(track: track, selection: $selection)
+                }
+            }
+        }
+        .navigationTitle("Archived tracks")
+        // TODO: Add edit mode for bulk unarchiving.
+    }
+}
+
+#Preview {
+    NavigationView {
+        ArchivedTracksView()
+    }
+    .navigationViewStyle(StackNavigationViewStyle())
+    // TODO: Make unified .previewEnvironment() modifier?
+    .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+    .environmentObject(TrackController(preview: true))
+    .environmentObject(ViewControllerContainer())
+}

--- a/Tickmate/Tickmate/Views/GroupView.swift
+++ b/Tickmate/Tickmate/Views/GroupView.swift
@@ -12,7 +12,11 @@ struct GroupView: View {
     
     //MARK: Properties
     
-    @FetchRequest(entity: Track.entity(), sortDescriptors: TrackController.sortDescriptors)
+    @FetchRequest(
+        entity: Track.entity(),
+        sortDescriptors: TrackController.sortDescriptors,
+        predicate: NSPredicate(format: "isArchived == NO")
+    )
     private var allTracks: FetchedResults<Track>
     
     @EnvironmentObject private var vcContainer: ViewControllerContainer

--- a/Tickmate/Tickmate/Views/GroupView.swift
+++ b/Tickmate/Tickmate/Views/GroupView.swift
@@ -57,7 +57,12 @@ struct GroupView: View {
         .navigationTitle("Group details")
         .onAppear {
             name = group.wrappedName
-            if let tracks = group.tracks as? Set<Track> {
+            if var tracks = group.tracks as? Set<Track> {
+                // Groups shouldn't have archived Tracks. Remove archived Tracks
+                // that might be here because of sync conflicts on load.
+                tracks
+                    .filter(\.isArchived)
+                    .forEach { track in tracks.remove(track) }
                 selectedTracks = tracks
             }
         }
@@ -87,7 +92,11 @@ struct GroupView: View {
                 }
             } label: {
                 HStack {
-                    Text(track.name ?? "New Track")
+                    Label(
+                        track.name ?? "New Track",
+                        systemImage: track.systemImage ?? "questionmark.square"
+                    )
+                    
                     if selectedTracks.contains(track) {
                         Spacer()
                         Image(systemName: "checkmark")

--- a/Tickmate/Tickmate/Views/TicksView.swift
+++ b/Tickmate/Tickmate/Views/TicksView.swift
@@ -13,6 +13,8 @@ import SwiftUIIntrospect
 
 struct TicksView: View {
     
+    // MARK: Properties
+    
     @Environment(\.managedObjectContext) private var moc
     
     private var fetchRequest: FetchRequest<Track>
@@ -32,12 +34,17 @@ struct TicksView: View {
     
     @State private var showingTrack: Track?
     
+    // MARK: Init
+    
+    private static var standardPredicate: String = "enabled == YES AND isArchived == NO"
+    
     init(scrollToBottomToggle: Bool = false) {
         self.scrollToBottomToggle = scrollToBottomToggle
         fetchRequest = FetchRequest(
             entity: Track.entity(),
             sortDescriptors: TrackController.sortDescriptors,
-            predicate: NSPredicate(format: "enabled == YES"))
+            predicate: NSPredicate(format: Self.standardPredicate)
+        )
     }
     
     init(group: TrackGroup, scrollToBottomToggle: Bool = false) {
@@ -45,7 +52,11 @@ struct TicksView: View {
         fetchRequest = FetchRequest(
             entity: Track.entity(),
             sortDescriptors: TrackController.sortDescriptors,
-            predicate: NSPredicate(format: "enabled == YES AND %@ IN groups", group))
+            predicate: NSPredicate(
+                format: Self.standardPredicate + " AND %@ IN groups",
+                group
+            )
+        )
     }
     
     init(fetchRequest: FetchRequest<Track>, scrollToBottomToggle: Bool = false) {
@@ -150,9 +161,10 @@ struct TicksView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             TicksView()
-                .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
-                .environmentObject(TrackController())
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+        .environmentObject(TrackController(preview: true))
+        .environmentObject(GroupController(preview: true))
     }
 }

--- a/Tickmate/Tickmate/Views/TrackView.swift
+++ b/Tickmate/Tickmate/Views/TrackView.swift
@@ -32,10 +32,17 @@ struct TrackView: View {
     @State private var actionSheet: Action?
     @State private var fixTextField = false
     
+    private var groupsEnabled: Bool {
+        groupsUnlocked && !track.isArchived
+    }
+    
+    @ViewBuilder
     private var groupsFooter: some View {
-        groupsUnlocked
-            ? AnyView(EmptyView())
-            : AnyView(Text("Unlock the groups upgrade from the settings page"))
+        if !groupsUnlocked {
+            Text("Unlock the groups upgrade from the settings page.")
+        } else if track.isArchived {
+            Text("Unarchive to add to groups.")
+        }
     }
     
     //MARK: Body
@@ -53,7 +60,7 @@ struct TrackView: View {
                             .foregroundColor(.secondary)
                     }
                 }
-                .disabled(!groupsUnlocked)
+                .disabled(!groupsEnabled)
             }
             
             Section(header: Text("Name")) {
@@ -275,8 +282,9 @@ struct TrackView: View {
     }
     
     private func archive() {
-        track.isArchived = true
+        track.archive()
         PersistenceController.save(context: moc)
+        selection = nil
     }
     
     private func unarchive() {

--- a/Tickmate/Tickmate/Views/TrackView.swift
+++ b/Tickmate/Tickmate/Views/TrackView.swift
@@ -276,12 +276,12 @@ struct TrackView: View {
     
     private func archive() {
         track.isArchived = true
-        trackController.scheduleSave()
+        PersistenceController.save(context: moc)
     }
     
     private func unarchive() {
         track.isArchived = false
-        trackController.scheduleSave()
+        PersistenceController.save(context: moc)
     }
     
     // MARK: Strings

--- a/Tickmate/Tickmate/Views/TracksView.swift
+++ b/Tickmate/Tickmate/Views/TracksView.swift
@@ -30,6 +30,10 @@ struct TracksView: View {
         trackController.fetchedResultsController.fetchedObjects ?? []
     }
     
+    private var shouldShowArchivedTracksLink: Bool {
+        !(trackController.archivedTracksFRC.fetchedObjects ?? []).isEmpty
+    }
+    
     //MARK: Body
     
     var body: some View {
@@ -66,6 +70,14 @@ struct TracksView: View {
                 #if os(iOS)
                 .foregroundColor(.accentColor)
                 #endif
+            }
+            
+            if shouldShowArchivedTracksLink {
+                Section {
+                    NavigationLink("Archive") {
+                        ArchivedTracksView()
+                    }
+                }
             }
         }
         .environment(\.editMode, $editMode)
@@ -186,9 +198,10 @@ struct TracksView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             TracksView(showing: .constant(true))
-                .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
-                .environmentObject(TrackController(preview: true))
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+        .environmentObject(TrackController(preview: true))
+        .environmentObject(ViewControllerContainer())
     }
 }

--- a/Tickmate/Tickmate/Views/TracksView.swift
+++ b/Tickmate/Tickmate/Views/TracksView.swift
@@ -205,6 +205,7 @@ struct TracksView_Previews: PreviewProvider {
         .navigationViewStyle(StackNavigationViewStyle())
         .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
         .environmentObject(TrackController(preview: true))
+        .environmentObject(GroupController(preview: true))
         .environmentObject(ViewControllerContainer())
     }
 }

--- a/Tickmate/Tickmate/Views/TracksView.swift
+++ b/Tickmate/Tickmate/Views/TracksView.swift
@@ -153,6 +153,7 @@ struct TrackCell: View {
     
     @ObservedObject var track: Track
     @Binding var selection: Track?
+    var shouldShowToggle = true
     
     private var caption: String {
         [track.multiple ? "Multiple" : nil, track.reversed ? "Reversed" : nil].compactMap { $0 }.joined(separator: ", ")
@@ -180,11 +181,13 @@ struct TrackCell: View {
                 }
                 TextWithCaption(text: track.name ?? "", caption: caption)
                 Spacer(minLength: 0)
-                Toggle(isOn: $track.enabled) {
-                    EmptyView()
-                }
-                .onChange(of: track.enabled) { _ in
-                    PersistenceController.save(context: moc)
+                
+                if shouldShowToggle {
+                    Toggle("Enabled", isOn: $track.enabled)
+                        .labelsHidden()
+                        .onChange(of: track.enabled) { _ in
+                            PersistenceController.save(context: moc)
+                        }
                 }
             }
         }

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -130,7 +130,7 @@ struct Provider: IntentTimelineProvider {
     private func tracksFetchRequest() -> NSFetchRequest<Track> {
         let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
         fetchRequest.sortDescriptors = TrackController.sortDescriptors
-        fetchRequest.predicate = NSPredicate(format: "enabled == YES")
+        fetchRequest.predicate = NSPredicate(format: "enabled == YES AND isArchived == NO")
         fetchRequest.fetchLimit = 8
         return fetchRequest
     }

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -290,8 +290,12 @@ struct TicksWidgetEntryView : View {
                 }
             }
         }
-        .padding(12)
-        .background(colorScheme == .dark ? Color(.systemGroupedBackground) : Color(.systemBackground))
+        .versionedBackground {
+            Color(colorScheme == .dark ? .systemGroupedBackground : .systemBackground)
+            // I don't know why this is needed, but manually
+            // setting the theme doesn't work without it.
+                .environment(\.colorScheme, self.colorScheme)
+        }
     }
     
     // You can uncomment this and the above Text for easier debugging
@@ -303,6 +307,19 @@ struct TicksWidgetEntryView : View {
         return dateFormatter
     }()
     */
+}
+
+private extension View {
+    @ViewBuilder
+    func versionedBackground(_ backgroundView: () -> some View) -> some View {
+        if #available(iOS 17.0, *) {
+            self.containerBackground(for: .widget) {
+                backgroundView()
+            }
+        } else {
+            self.padding().background(backgroundView())
+        }
+    }
 }
 
 //MARK: TicksWidget
@@ -339,11 +356,16 @@ struct TicksWidget_Previews: PreviewProvider {
     
     static var previews: some View {
         ticksWidget(tracksCount: 3, days: 2, family: .systemSmall)
+            .previewDisplayName("3 tracks, 2 days, small")
         ticksWidget(tracksCount: 4, days: 5, family: .systemSmall)
             .environment(\.colorScheme, .dark)
+            .previewDisplayName("4 tracks, 5 days, small, dark")
         ticksWidget(tracksCount: 5, days: 4, family: .systemMedium)
+            .previewDisplayName("4 tracks, 5 days, medium")
         ticksWidget(tracksCount: 4, days: 7, family: .systemLarge)
+            .previewDisplayName("4 tracks, 7 days, large")
         ticksWidget(tracksCount: 5, days: 10, family: .systemLarge)
+            .previewDisplayName("5 tracks, 10 days, large")
     }
     
     static func tracks(_ count: Int) -> [Track] {

--- a/Tickmate/TicksWidgetIntentsExtension/IntentHandler.swift
+++ b/Tickmate/TicksWidgetIntentsExtension/IntentHandler.swift
@@ -20,6 +20,9 @@ class IntentHandler: INExtension, ConfigurationIntentHandling {
     func provideTracksOptionsCollection(for intent: ConfigurationIntent, with completion: @escaping (INObjectCollection<TrackItem>?, Error?) -> Void) {
         let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Track.index, ascending: true)]
+        // If dynamic widgets are added, `enabled == YES` could maybe be removed
+        // in case there are Tracks you want _only_ displayed in the widget.
+        fetchRequest.predicate = NSPredicate(format: "enabled == YES AND isArchived == NO")
         
         do {
             let context = PersistenceController.shared.container.viewContext


### PR DESCRIPTION
Archiving a Track makes it no longer appear in the main Tick view. It also hides it from the Track list and puts it instead in a separate Archived Tracks page linked at the bottom of the track list.

Archiving tracks is useful if you previously tracked something that is no longer relevant to you, but you don't want to delete it and lose all of its historical data.