### PR TITLE
Allow days to be sorted with today at the top

### DIFF
--- a/Tickmate/Tickmate/Model/Defaults.swift
+++ b/Tickmate/Tickmate/Model/Defaults.swift
@@ -2,7 +2,7 @@
 //  Defaults.swift
 //  Tickmate
 //
-//  Created by Isaac Lyons on 3/9/21.
+//  Created by Elaine Lyons on 3/9/21.
 //
 
 import Foundation
@@ -23,4 +23,5 @@ enum Defaults: String {
     case appGroupDatabaseMigration  // Bool
     case userDefaultsMigration      // Bool     App Group
     case lastUpdateTime             // String   App Group
+    case todayAtTop                 // Bool     App Group
 }

--- a/Tickmate/Tickmate/TickmateApp.swift
+++ b/Tickmate/Tickmate/TickmateApp.swift
@@ -2,7 +2,7 @@
 //  TickmateApp.swift
 //  Tickmate
 //
-//  Created by Isaac Lyons on 2/19/21.
+//  Created by Elaine Lyons on 2/19/21.
 //
 
 import SwiftUI

--- a/Tickmate/Tickmate/Views/SettingsView.swift
+++ b/Tickmate/Tickmate/Views/SettingsView.swift
@@ -17,6 +17,9 @@ struct SettingsView: View {
     @AppStorage(Defaults.weekStartDay.rawValue, store: UserDefaults(suiteName: groupID))
     private var weekStartDay = 2
     
+    @AppStorage(Defaults.todayAtTop.rawValue, store: UserDefaults(suiteName: groupID))
+    private var todayAtTop = false
+    
     @AppStorage(Defaults.weekSeparatorSpaces.rawValue) private var weekSeparatorSpaces: Bool = true
     @AppStorage(Defaults.weekSeparatorLines.rawValue) private var weekSeparatorLines: Bool = true
     @AppStorage(Defaults.relativeDates.rawValue) private var relativeDates = true
@@ -47,6 +50,15 @@ struct SettingsView: View {
                             text: "New day start time",
                             caption: "")
                     }
+                }
+            }
+            
+            Section {
+                Picker("Put today at the", selection: $todayAtTop) {
+                    Text("top")
+                        .tag(true)
+                    Text("bottom")
+                        .tag(false)
                 }
             }
             
@@ -167,6 +179,9 @@ struct SettingsView: View {
         }
         .onChange(of: customDayStart, perform: updateCustomDayStart)
         .onChange(of: timeOffset, perform: updateCustomDayStart)
+        .onChange(of: todayAtTop) { _ in
+            trackController.scheduleTimelineRefresh()
+        }
         .onChange(of: weekStartDay) { value in
             trackController.weekStartDay = value
         }

--- a/Tickmate/Tickmate/Views/TickView.swift
+++ b/Tickmate/Tickmate/Views/TickView.swift
@@ -34,8 +34,8 @@ struct DayRow<C: RandomAccessCollection>: View where C.Element == Track {
     }
     
     @ViewBuilder
-    private var backgroud: some View {
-        if lines && trackController.weekend(day: day) {
+    private var background: some View {
+        if lines && trackController.shouldShowSeparatorBelow(day: day) {
             VStack {
                 Spacer()
                 Capsule()
@@ -70,7 +70,7 @@ struct DayRow<C: RandomAccessCollection>: View where C.Element == Track {
                     .opacity(0)
             }
         }
-        .listRowBackground(backgroud)
+        .listRowBackground(background)
         .id(day)
     }
 }

--- a/Tickmate/Tickmate/Views/TicksView.swift
+++ b/Tickmate/Tickmate/Views/TicksView.swift
@@ -22,6 +22,8 @@ struct TicksView: View {
         fetchRequest.wrappedValue
     }
     
+    @AppStorage(Defaults.todayAtTop.rawValue, store: UserDefaults(suiteName: groupID))
+    private var todayAtTop = false
     @AppStorage(Defaults.weekSeparatorLines.rawValue) private var weekSeparatorLines: Bool = true
     @AppStorage(Defaults.weekSeparatorSpaces.rawValue) private var weekSeparatorSpaces: Bool = true
     
@@ -122,24 +124,31 @@ struct TicksView: View {
             
             ScrollViewReader { proxy in
                 List {
-                    Button("Go to bottom") {
-                        proxy.scrollTo(0)
+                    if !todayAtTop {
+                        Button("Go to bottom") {
+                            proxy.scrollTo(0)
+                        }
                     }
                     
-                    ForEach(0..<365) { dayComplement in
-                        DayRow(364 - dayComplement, tracks: tracks, spaces: weekSeparatorSpaces, lines: weekSeparatorLines)
-                            .listRowInsets(.init(top: 4, leading: 0, bottom: 4, trailing: 0))
-                            #if os(iOS)
-                            .padding(.horizontal)
-                            #endif
+                    ForEach(0..<365) { row in
+                        DayRow(
+                            todayAtTop ? row : 364 - row,
+                            tracks: tracks,
+                            spaces: weekSeparatorSpaces,
+                            lines: weekSeparatorLines
+                        )
+                        .listRowInsets(.init(top: 4, leading: 0, bottom: 4, trailing: 0))
+                        #if os(iOS)
+                        .padding(.horizontal)
+                        #endif
                     }
                 }
                 .listStyle(PlainListStyle())
                 .introspect(.list, on: .iOS(.v14, .v15)) { tableView in
-                    tableView.scrollsToTop = false
+                    tableView.scrollsToTop = todayAtTop
                 }
                 .introspect(.list, on: .iOS(.v16, .v17)) { collectionView in
-                    collectionView.scrollsToTop = false
+                    collectionView.scrollsToTop = todayAtTop
                 }
                 .padding(0)
                 .onAppear {

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -172,6 +172,9 @@ struct TicksWidgetEntryView : View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.widgetFamily) private var widgetFamily
     
+    @AppStorage(Defaults.todayAtTop.rawValue, store: UserDefaults(suiteName: groupID))
+    private var todayAtTop = false
+    
     //MARK: Properties
     
     var entry: Provider.Entry
@@ -204,6 +207,14 @@ struct TicksWidgetEntryView : View {
         entry.configuration.daysMode == .automatic
             ? defaultNumDays
             : min(entry.configuration.numDays?.intValue ?? defaultNumDays, maxNumDays)
+    }
+    
+    struct Row: Identifiable {
+        var id: Int { value }
+        var value: Int
+    }
+    var rows: [Row] {
+        (0..<numDays).map(Row.init(value:))
     }
     
     var defaultNumTracks: Int {
@@ -273,13 +284,13 @@ struct TicksWidgetEntryView : View {
                 Divider()
             }
             
-            ForEach(0..<numDays) { dayComplement in
-                let day = numDays - 1 - dayComplement
+            ForEach(rows) { row in
+                let day = todayAtTop ? row.value : (numDays - 1 - row.value)
                 DayRow(day, tracks: tracks, spaces: false, lines: false, widget: true, compact: compact)
                 
-                if dayComplement < numDays - 1 {
-                    if entry.configuration.weekSeparators?.boolValue ?? true
-                        && entry.trackController.weekend(day: day) {
+                if row.value < numDays - 1 {
+                    if entry.configuration.weekSeparators?.boolValue ?? true,
+                       entry.trackController.shouldShowSeparatorBelow(day: day) {
                         Capsule()
                             .foregroundColor(.gray)
                             .frame(height: 2)


### PR DESCRIPTION
Adds a new setting that flips the order of the day rows to put today at the top instead of the default bottom.

Closes #70