### PR TITLE
Start app on correct group page

### DIFF
--- a/Tickmate/Tickmate/Supplementary Views/PageView.swift
+++ b/Tickmate/Tickmate/Supplementary Views/PageView.swift
@@ -54,7 +54,10 @@ struct PageView<Content: View>: View {
                 }
             )
             .onChange(of: pageCount) { _ in updatePage() }
-            .onAppear(perform: updatePage)
+            .onAppear {
+                updatePage()
+                updateOffset(geometryReaderWidth: geo.size.width)
+            }
         }
     }
     


### PR DESCRIPTION
Technically not a perfect fix because it still flashes the first frame very briefly, but I think it's better than before 
Closes #95